### PR TITLE
Add cross-compilation support from any to macOS

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,9 @@
 const bld = @import("std").build;
 
 pub fn build(b: *bld.Builder) void {
+    const target = b.standardTargetOptions(.{});
     const exe = b.addExecutable("pacman", "src/pacman.zig");
+    exe.setTarget(target);
     addSokol(exe);
     exe.setBuildMode(b.standardReleaseOptions());
     exe.addPackagePath("sokol", "src/sokol/sokol.zig");
@@ -12,6 +14,11 @@ pub fn build(b: *bld.Builder) void {
 fn addSokol(exe: *bld.LibExeObjStep) void {
     exe.linkLibC();
     if (exe.target.isDarwin()) {
+        if (!@import("builtin").target.isDarwin()) {
+            exe.addSystemIncludeDir("/usr/include");
+            exe.addLibPath("/usr/lib");
+            exe.addFrameworkDir("/System/Library/Frameworks");
+        }
         exe.addCSourceFile("src/sokol/sokol.c", &.{ "-ObjC" });
         exe.linkFramework("MetalKit");
         exe.linkFramework("Metal");


### PR DESCRIPTION
When cross-compiling to macOS from Linux say, it is required to
point to a valid sysroot via the `--sysroot` flag:

```
zig build --sysroot /path/to/macos-sdk-sysroot/ -Dtarget=x86_64-macos
zig build --sysroot /path/to/macos-sdk-sysroot/ -Dtarget=aarch64-macos
```